### PR TITLE
Removed apostrophe and updated listing structure

### DIFF
--- a/source/intro.rst
+++ b/source/intro.rst
@@ -54,7 +54,7 @@ Productive
 ----------
 
 Go is frequently - and favorably - compared with Python and Ruby for programmer
-productivity.  It's clean elegant syntax, unobtrusive static typing, optional
+productivity.  Its clean and elegant syntax, unobtrusive static typing, optional
 duck typing, batteries-included standard library, lighting-fast compiliation,
 and support for a variety of modern continuous integrtion tools make Go a
 productivity champion.


### PR DESCRIPTION
"Its" denotes possession without the apostrophe. "It's" means "it is".

"clean elegant syntax" ought to be "clean, elegant syntax"; however, if we were to do that, then the rest of the commas for the following list would need to be semicolons, so I used a conjunction ("and") instead of the comma.